### PR TITLE
AI Assistant tab: reorder + remove Sources; legacy mode support

### DIFF
--- a/src/components/ScoobyAI.tsx
+++ b/src/components/ScoobyAI.tsx
@@ -21,9 +21,10 @@ interface ScoobyAIProps {
   isLoading?: boolean
   onSaveDrug?: (drugId: string) => void
   savedDrugIds?: Set<string>
+  showSources?: boolean
 }
 
-export default function ScoobyAI({ onSendMessage, isLoading, onSaveDrug, savedDrugIds }: ScoobyAIProps) {
+export default function ScoobyAI({ onSendMessage, isLoading, onSaveDrug, savedDrugIds, showSources = false }: ScoobyAIProps) {
   const [messages, setMessages] = useState<Message[]>([
     {
       id: 'welcome',
@@ -119,14 +120,14 @@ export default function ScoobyAI({ onSendMessage, isLoading, onSaveDrug, savedDr
         </div>
 
         {/* Conversation Area */}
-        <div className="bg-[#F8F9FA] h-80 overflow-y-auto p-6 flex flex-col gap-4">
+        <div className="bg-[#F8F9FA] min-h-[360px] h-[460px] xl:h-[560px] overflow-y-auto p-6 flex flex-col gap-4">
           {messages.map((message) => (
             <div
               key={message.id}
               className={`flex ${message.type === 'user' ? 'justify-end' : 'justify-start'}`}
             >
               <div
-                className={`max-w-2xl rounded-3xl px-4 py-3 shadow-sm ${
+                className={`max-w-3xl rounded-3xl px-4 py-3 shadow-sm ${
                   message.type === 'user'
                     ? 'bg-[#4376EC] text-white ml-8'
                     : 'bg-white text-gray-800 mr-8'
@@ -145,7 +146,7 @@ export default function ScoobyAI({ onSendMessage, isLoading, onSaveDrug, savedDr
                 <div className="text-sm leading-relaxed">
                   {message.content}
                 </div>
-                {message.sources && message.sources.length > 0 && (
+                {showSources && message.sources && message.sources.length > 0 && (
                   <div className="mt-3 pt-3 border-t border-gray-200">
                     <div className="text-xs text-gray-600 font-medium mb-1">Sources:</div>
                     <div className="text-xs text-gray-500">
@@ -159,7 +160,7 @@ export default function ScoobyAI({ onSendMessage, isLoading, onSaveDrug, savedDr
           
           {(isTyping || isLoading) && (
             <div className="flex justify-start">
-              <div className="bg-white text-gray-800 rounded-3xl px-4 py-3 shadow-sm mr-8 max-w-2xl">
+              <div className="bg-white text-gray-800 rounded-3xl px-4 py-3 shadow-sm mr-8 max-w-3xl">
                 <div className="text-[#4376EC] text-xs font-semibold uppercase tracking-wider mb-2">
                   AI Assistant
                 </div>


### PR DESCRIPTION
Changes\n- UI: Rename Chatbot tab label to 'AI Assistant' and move it to the second position after Drug Database.\n- UI: Remove 'Sources' display from the assistant response panel.\n- API: Add 'legacy' and 'assistant' modes to /api/chat (legacy uses the previous prompt style, assistant uses concise bullets).\n- Stability: We validated CSS links under dev flow to avoid hash mismatches.\n\nNotes\n- URLs still use ?tab=chatbot for deep-linking; only the label changed. If preferred, we can migrate to ?tab=assistant and add redirect.\n- No data model changes.